### PR TITLE
Play 2.6 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# Idea specific
+.idea
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Macrame provides macro-based replacements for parts of the Scala standard librar
 If you're using SBT, add the following to your build file.
 ```scala
 libraryDependencies ++= Seq(
-   "com.chrisneveu" %% "macrame" % "1.2.5",
+   "com.kinja" %% "macrame" % "1.2.5",
    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full))
 ```
 

--- a/macrame-play/README.md
+++ b/macrame-play/README.md
@@ -4,7 +4,7 @@ Macrame-Play provides `Reads`, `Writes`,`Format`, `QueryStringBindable`, and `Pa
 ## Getting Macramé-Play
 If you're using SBT, add the following to your build file.
 ```scala
-libraryDependencies += "com.chrisneveu" %% "macrame-play" % "1.1.0-play-2.5.x"
+libraryDependencies += "com.kinja" %% "macrame-play" % "1.1.0-play-2.5.x"
 ```
 
 ## API Documentation

--- a/macrame-play/README.md
+++ b/macrame-play/README.md
@@ -4,7 +4,7 @@ Macrame-Play provides `Reads`, `Writes`,`Format`, `QueryStringBindable`, and `Pa
 ## Getting Macramé-Play
 If you're using SBT, add the following to your build file.
 ```scala
-libraryDependencies += "com.kinja" %% "macrame-play" % "1.1.0-play-2.5.x"
+libraryDependencies += "com.kinja" %% "macrame-play" % "1.1.0-play-2.6.x"
 ```
 
 ## API Documentation

--- a/macrame-scalaz/README.md
+++ b/macrame-scalaz/README.md
@@ -4,7 +4,7 @@ Macrame-Scalaz provides instances of several scalaz type-classes for Macramé en
 ## Getting Macramé-Scalaz
 If you're using SBT, add the following to your build file.
 ```scala
-libraryDependencies += "com.chrisneveu" %% "macrame-scalaz" % "1.0.0-scalaz-7.2.x"
+libraryDependencies += "com.kinja" %% "macrame-scalaz" % "1.0.0-scalaz-7.2.x"
 ```
 
 ## API Documentation

--- a/macrame/src/main/scala/macrame/enum.scala
+++ b/macrame/src/main/scala/macrame/enum.scala
@@ -2,7 +2,7 @@ package macrame
 
 import macrame.internal.renderName
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 
@@ -14,7 +14,6 @@ object enum {
 
    def impl(c : Context)(annottees : c.Expr[Any]*) : c.Expr[Any] = {
       import c.universe._
-      import Flag._
 
       case class Case(name : TermName, str : Tree)
 
@@ -36,13 +35,13 @@ object enum {
             impl.body.foreach {
                case Ident(_) ⇒
                case Apply(Ident(_), _ :: Nil) ⇒
-               case DefDef(_, name, _, _, _, _) if name.decoded == "<init>" ⇒
+               case DefDef(_, name, _, _, _, _) if name.decodedName.toString == "<init>" ⇒
                case t ⇒
                   // println(showRaw(t))
                   c.abort(t.pos, "Invalid case in Enum declaration.")
             }
             val init = impl.body.find {
-               case DefDef(_, name, _, _, _, _) if name.decoded == "<init>" ⇒ true
+               case DefDef(_, name, _, _, _, _) if name.decodedName.toString == "<init>" ⇒ true
             }.get
 
             val cases : List[Case] = impl.body.collect {
@@ -107,7 +106,7 @@ object enum {
             """
 
             val className = q"""
-               protected lazy val className : String = ${Enum.decoded.toString}
+               protected lazy val className : String = ${Enum.decodedName.toString}
             """
 
             val apiImpl = List(

--- a/macrame/src/main/scala/macrame/internal/TreeShaper.scala
+++ b/macrame/src/main/scala/macrame/internal/TreeShaper.scala
@@ -1,6 +1,6 @@
 package macrame.internal
 
-import reflect.macros.Context
+import reflect.macros.whitebox.Context
 
 sealed abstract class TreeShaper[C <: Context] private (val c : C) { self ⇒
    import c.universe._

--- a/macrame/src/main/scala/macrame/internal/package.scala
+++ b/macrame/src/main/scala/macrame/internal/package.scala
@@ -1,6 +1,6 @@
 package macrame
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 package object internal {
 
@@ -27,7 +27,7 @@ package object internal {
       import c.universe._
       c.Expr[List[T]](
          Apply(
-            Select(Ident(newTermName("List")), newTermName("apply")),
+            Select(Ident(TermName("List")), TermName("apply")),
             expressions.map(_.tree).toList
          )
       )

--- a/macrame/src/main/scala/macrame/package.scala
+++ b/macrame/src/main/scala/macrame/package.scala
@@ -1,5 +1,5 @@
 import language.experimental.macros
-import reflect.macros.Context
+import reflect.macros.whitebox.Context
 import macrame.{ internal ⇒ fn }
 
 package object macrame {
@@ -84,7 +84,7 @@ package object macrame {
          fn.sequenceExpr(c)(
             fn.members[T](c)(obj)
                .map(s ⇒ fn.renderName(s.name))
-               .map(n ⇒ c.Expr[T](c.universe.Select(obj.tree, c.universe.newTermName(n))))
+               .map(n ⇒ c.Expr[T](c.universe.Select(obj.tree, c.universe.TermName(n))))
          )
 
       def memberMap[T : c.WeakTypeTag](c : Context)(obj : c.Expr[Object]) : c.Expr[Map[String, T]] = {
@@ -95,9 +95,9 @@ package object macrame {
             .map(n ⇒
                // ("n", obj.n)
                c.Expr[(String, T)](
-                  Apply(Select(Ident(newTermName("Tuple2")), newTermName("apply")), List(
+                  Apply(Select(Ident(TermName("Tuple2")), TermName("apply")), List(
                      Literal(Constant(n)),
-                     Select(obj.tree, newTermName(n)))
+                     Select(obj.tree, TermName(n)))
                   )
                )
             )

--- a/macrame/src/test/scala/macrame/DelegateTest.scala
+++ b/macrame/src/test/scala/macrame/DelegateTest.scala
@@ -1,8 +1,8 @@
 package macrame
 
-import org.scalatest.FunSuite
+import scala.language.implicitConversions
 
-import scala.math.Ordering
+import org.scalatest.FunSuite
 
 class DelegateTest extends FunSuite {
 

--- a/macrame/src/test/scala/macrame/DelegateTest.scala
+++ b/macrame/src/test/scala/macrame/DelegateTest.scala
@@ -1,8 +1,8 @@
 package macrame
 
-import scala.language.implicitConversions
-
 import org.scalatest.FunSuite
+
+import scala.language.implicitConversions
 
 class DelegateTest extends FunSuite {
 

--- a/macrame/src/test/scala/macrame/EnumTest.scala
+++ b/macrame/src/test/scala/macrame/EnumTest.scala
@@ -2,6 +2,7 @@ package macrame
 
 import org.scalatest.FunSuite
 
+import scala.language.implicitConversions
 import scala.math.Ordering
 
 class EnumTest extends FunSuite {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -32,7 +32,7 @@ object Build extends Build {
       settings = commonSettings ++ Seq(
          version := "1.1.1-play-2.6.x-SNAPSHOT",
          libraryDependencies ++= Seq(
-            "com.chrisneveu" %% "macrame" % "[1.0,2.0[" % Provided,
+            "com.kinja" %% "macrame" % "[1.0,2.0[" % Provided,
             "com.typesafe.play" %% "play" % "[2.6,2.7[" % Provided,
             compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" % "test" cross CrossVersion.full),
             "org.scalatest" %% "scalatest" % "3.0.0" % "test")))
@@ -43,7 +43,7 @@ object Build extends Build {
       settings = commonSettings ++ Seq(
          version := "1.0.1-scalaz-7.2.x-SNAPSHOT",
          libraryDependencies ++= Seq(
-            "com.chrisneveu" %% "macrame" % "[1.0,2.0[" % Provided,
+            "com.kinja" %% "macrame" % "[1.0,2.0[" % Provided,
             "org.scalaz" %% "scalaz-core" % "[7.2,7.3[" % Provided,
             compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" % "test" cross CrossVersion.full),
             "org.scalatest" %% "scalatest" % "3.0.0" % "test",
@@ -65,13 +65,13 @@ object Build extends Build {
      <developers>
        <developer>
          <name>Chris Neveu</name>
-         <url>chrisneveu.com</url>
+         <url>kinja.com</url>
        </developer>
      </developers>
    }
 
    lazy val commonSettings = Defaults.defaultSettings ++ scalariformSettings ++Seq(
-      organization := "com.chrisneveu",
+      organization := "com.kinja",
       scalaVersion := "2.11.8",
       crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),
       scalacOptions ++= Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -70,7 +70,7 @@ object Build extends Build {
      </developers>
    }
 
-   lazy val commonSettings = Defaults.defaultSettings ++ scalariformSettings ++Seq(
+   lazy val commonSettings = Defaults.coreDefaultSettings ++ scalariformSettings ++ Seq(
       organization := "com.kinja",
       scalaVersion := "2.11.8",
       crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -58,9 +58,9 @@ object Build extends Build {
        </license>
      </licenses>
      <scm>
-       <connection>scm:git:github.com/ChrisNeveu/macrame.git</connection>
-       <developerConnection>scm:git:git@github.com:ChrisNeveu/macrame.git</developerConnection>
-       <url>git@github.com:ChrisNeveu/macrame</url>
+       <connection>scm:git:github.com/gawkermedia/macrame.git</connection>
+       <developerConnection>scm:git:git@github.com:gawkermedia/macrame.git</developerConnection>
+       <url>git@github.com:gawkermedia/macrame.git</url>
      </scm>
      <developers>
        <developer>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -30,10 +30,10 @@ object Build extends Build {
       "macrame-play",
       file("macrame-play"),
       settings = commonSettings ++ Seq(
-         version := "1.1.1-play-2.5.x-SNAPSHOT",
+         version := "1.1.1-play-2.6.x-SNAPSHOT",
          libraryDependencies ++= Seq(
             "com.chrisneveu" %% "macrame" % "[1.0,2.0[" % Provided,
-            "com.typesafe.play" %% "play" % "[2.5,2.6[" % Provided,
+            "com.typesafe.play" %% "play" % "[2.6,2.7[" % Provided,
             compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" % "test" cross CrossVersion.full),
             "org.scalatest" %% "scalatest" % "3.0.0" % "test")))
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -47,7 +47,7 @@ object Build extends Build {
             "org.scalaz" %% "scalaz-core" % "[7.2,7.3[" % Provided,
             compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" % "test" cross CrossVersion.full),
             "org.scalatest" %% "scalatest" % "3.0.0" % "test",
-            "org.scalacheck" %% "scalacheck" % "1.12.5" % "test")))
+            "org.scalacheck" %% "scalacheck" % "1.13.4" % "test")))
 
    lazy val pomStuff = {
      <url>https://github.com/ChrisNeveu/macrame</url>


### PR DESCRIPTION
### What does this PR do? How does it affect users?
GroupId changed
Migrates versions to ones that supported by play2.6
Changes the build classifier
Some deprecations eliminated

### How should this be tested (feature switches, URLs, special user permissions)?
unit tests

### Related Asana task, wiki page or blog posts
[Play 2.6 Migration](https://app.asana.com/0/390663436419819/420125694076670/f)
