### PR TITLE
Play 2.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,7 @@ lazy val macrameScalaz = Project("macrame-scalaz", file("macrame-scalaz"))
       publishTo := sonatypePublishTo.value,
       sonatypeProjectHosting := (Global / sonatypeProjectHosting).value,
       libraryDependencies ++= Seq(
-         "org.scalaz" %% "scalaz-core" % "[7.2,7.3[" % Provided,
+         "org.scalaz" %% "scalaz-core" % "[7.2,7.3)" % Provided,
          "org.scalatest" %% "scalatest" % "3.0.8" % Test,
          "org.scalacheck" %% "scalacheck" % "1.14.0" % Test)
    )

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ inThisBuild(Seq(
    organizationHomepage := Some(url("https://kinja.com/")),
 
    scalaVersion := "2.12.8",
-   crossScalaVersions := Seq("2.13.1", "2.12.8", "2.11.12"),
+   crossScalaVersions := Seq("2.13.1", "2.12.8"),
 
    scalacOptions ++= Seq(
       "-unchecked",                        // Show details of unchecked warnings.

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ inThisBuild(Seq(
    organizationHomepage := Some(url("https://kinja.com/")),
 
    scalaVersion := "2.12.8",
-   crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12"),
+   crossScalaVersions := Seq("2.13.1", "2.12.8", "2.11.12"),
 
    scalacOptions ++= Seq(
       "-unchecked",                        // Show details of unchecked warnings.

--- a/build.sbt
+++ b/build.sbt
@@ -96,11 +96,11 @@ lazy val macrame = Project("macrame", file("macrame"))
 
 lazy val macramePlay = Project("macrame-play", file("macrame-play"))
    .settings(
-      version := "1.1.4-play-2.7.x",
+      version := "1.1.4-play-2.8.x",
       publishTo := sonatypePublishTo.value,
       sonatypeProjectHosting := (Global / sonatypeProjectHosting).value,
       libraryDependencies ++= Seq(
-         "com.typesafe.play" %% "play" % "[2.7,2.8[" % Provided,
+         "com.typesafe.play" %% "play" % "[2.8,2.9[" % Provided,
          "org.scalatest" %% "scalatest" % "3.0.8" % Test)
    )
    .dependsOn(macrame)

--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val macramePlay = Project("macrame-play", file("macrame-play"))
       publishTo := sonatypePublishTo.value,
       sonatypeProjectHosting := (Global / sonatypeProjectHosting).value,
       libraryDependencies ++= Seq(
-         "com.typesafe.play" %% "play" % "[2.8,2.9[" % Provided,
+         "com.typesafe.play" %% "play" % "2.8.1" % Provided,
          "org.scalatest" %% "scalatest" % "3.0.8" % Test)
    )
    .dependsOn(macrame)

--- a/macrame-play/src/main/scala/macrame/play/enums/Enum.scala
+++ b/macrame-play/src/main/scala/macrame/play/enums/Enum.scala
@@ -23,6 +23,9 @@ trait AsJson[E] { self : EnumApi[E] =>
    implicit val writes : Writes[E] = new Writes[E] {
       def writes(enum : E) : JsValue = JsString(asStringImpl(enum))
    }
+   implicit def enumValueWrites[V <: E] : Writes[V] = new Writes[V] {
+      def writes(value : V) : JsValue = JsString(asStringImpl(value))
+   }
 }
 
 /**

--- a/macrame-play/src/test/scala/macrame/play/enums/EnumTest.scala
+++ b/macrame-play/src/test/scala/macrame/play/enums/EnumTest.scala
@@ -19,9 +19,9 @@ class EnumTest extends FunSuite {
       }
       object Color extends AsJson[Color]
 
-      assert(Json.toJson(Color.Red) == JsString("Red"))
-      assert(Json.toJson(Color.Blue) == JsString("BLUE"))
-      assert(Json.toJson(Color.Yellow) == JsString("YELLOW"))
+      assert(Json.toJson(Color.Red : Color) == JsString("Red"))
+      assert(Json.toJson(Color.Blue : Color) == JsString("BLUE"))
+      assert(Json.toJson(Color.Yellow : Color) == JsString("YELLOW"))
    }
 
    test("FromJson should work.") {

--- a/macrame-play/src/test/scala/macrame/play/enums/EnumTest.scala
+++ b/macrame-play/src/test/scala/macrame/play/enums/EnumTest.scala
@@ -19,9 +19,9 @@ class EnumTest extends FunSuite {
       }
       object Color extends AsJson[Color]
 
-      assert(Json.toJson(Color.Red : Color) == JsString("Red"))
-      assert(Json.toJson(Color.Blue : Color) == JsString("BLUE"))
-      assert(Json.toJson(Color.Yellow : Color) == JsString("YELLOW"))
+      assert(Json.toJson(Color.Red) == JsString("Red"))
+      assert(Json.toJson(Color.Blue) == JsString("BLUE"))
+      assert(Json.toJson(Color.Yellow) == JsString("YELLOW"))
    }
 
    test("FromJson should work.") {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.7


### PR DESCRIPTION
Changes supported the Play version in `macrame-play` from 2.7 to 2.8.

Removing Scala 2.11 support because Play 2.8 no longer has a 2.11 build.